### PR TITLE
Statistical tests

### DIFF
--- a/flux_to_map.py
+++ b/flux_to_map.py
@@ -638,6 +638,7 @@ def computePValue(dataset1Data: List[float], dataset2Data: List[float]) -> Tuple
             if len(dataset1Data) != len(dataset2Data):
                 raise ValueError("Datasets must have the same size for Wilcoxon signed-rank test.")
             # Perform Wilcoxon signed-rank test
+            np.random.seed(42)  # Ensure reproducibility since zsplit method is used
             _, p_value = st.wilcoxon(dataset1Data, dataset2Data, zero_method="zsplit")
         case "mw":
             # Perform Mann-Whitney U test

--- a/flux_to_map.py
+++ b/flux_to_map.py
@@ -638,7 +638,7 @@ def computePValue(dataset1Data: List[float], dataset2Data: List[float]) -> Tuple
             if len(dataset1Data) != len(dataset2Data):
                 raise ValueError("Datasets must have the same size for Wilcoxon signed-rank test.")
             # Perform Wilcoxon signed-rank test
-            _, p_value = st.wilcoxon(dataset1Data, dataset2Data)
+            _, p_value = st.wilcoxon(dataset1Data, dataset2Data, zero_method="zsplit")
         case "mw":
             # Perform Mann-Whitney U test
             _, p_value = st.mannwhitneyu(dataset1Data, dataset2Data)

--- a/marea.py
+++ b/marea.py
@@ -729,6 +729,7 @@ def computePValue(dataset1Data: List[float], dataset2Data: List[float]) -> Tuple
             if len(dataset1Data) != len(dataset2Data):
                 raise ValueError("Datasets must have the same size for Wilcoxon signed-rank test.")
             # Perform Wilcoxon signed-rank test
+            np.random.seed(42) # Ensure reproducibility since zsplit method is used
             _, p_value = st.wilcoxon(dataset1Data, dataset2Data, zero_method='zsplit')
         case "mw":
             # Perform Mann-Whitney U test

--- a/marea.py
+++ b/marea.py
@@ -729,7 +729,7 @@ def computePValue(dataset1Data: List[float], dataset2Data: List[float]) -> Tuple
             if len(dataset1Data) != len(dataset2Data):
                 raise ValueError("Datasets must have the same size for Wilcoxon signed-rank test.")
             # Perform Wilcoxon signed-rank test
-            _, p_value = st.wilcoxon(dataset1Data, dataset2Data)
+            _, p_value = st.wilcoxon(dataset1Data, dataset2Data, zero_method='zsplit')
         case "mw":
             # Perform Mann-Whitney U test
             _, p_value = st.mannwhitneyu(dataset1Data, dataset2Data)


### PR DESCRIPTION
fix: wilcoxon methods raised error if datasets are exactly equal now it is handled with zsplit + fixed random seed.